### PR TITLE
Migrate to Chainguard node base image with pinned digest

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,23 @@
+name: "Check for newer image versions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At the start of every day
+    - cron: "0 0 * * *"
+
+jobs:
+  digest-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: navikt/digestabot@v1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          team: meldekort

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24@sha256:d84eaf833b497938d9bf029c218e5490512e23032d467a5d5b82ca22c9bb35e4 AS base
+FROM node:24-alpine AS base
 RUN corepack enable
 RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
     pnpm config set //npm.pkg.github.com/:_authToken=$(cat /run/secrets/NODE_AUTH_TOKEN)

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pnpm install --ignore-scripts --frozen-lockfile --prod
 RUN rm -rf node_modules/.pnpm/@esbuild*
 
 # runtime
-FROM gcr.io/distroless/nodejs24-debian12 AS runtime
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24@sha256:d84eaf833b497938d9bf029c218e5490512e23032d467a5d5b82ca22c9bb35e4 AS runtime
 COPY --from=prod-deps /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24@sha256:d84eaf833b497938d9bf029c218e5490512e23032d467a5d5b82ca22c9bb35e4 AS base
 RUN corepack enable
 RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
     pnpm config set //npm.pkg.github.com/:_authToken=$(cat /run/secrets/NODE_AUTH_TOKEN)


### PR DESCRIPTION
Replace gcr.io/distroless nodejs image with Chainguard node pinned to digest to fix libpng CVEs (CVE-2026-22801, CVE-2026-22695, CVE-2026-25646). Add digestabot workflow for automatic digest updates.

Trello-kort: https://trello.com/c/f9VWHk84